### PR TITLE
Comment TestPyPi from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,11 @@ jobs:
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@v1.8.12
 
-      - name: Publish package on TestPyPI
-        if: (!steps.check-version.outputs.tag)
-        uses: pypa/gh-action-pypi-publish@v1.8.12
-        with:
-          repository-url: https://test.pypi.org/legacy/
+      #- name: Publish package on TestPyPI
+      #  if: (!steps.check-version.outputs.tag)
+      #  uses: pypa/gh-action-pypi-publish@v1.8.12
+      #  with:
+      #    repository-url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v6.0.0


### PR DESCRIPTION
We do not have access to the TestPyPi account, and as such we can not add this package as a trusted publisher