### PR TITLE
110 application of timezone moves publishing date forward one day

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-statbank-client"
-version = "1.1.0"
+version = "1.1.1"
 description = "Handles data transfer Statbank <-> Dapla for Statistics Norway"
 authors = ["Statistics Norway", "Carl F. Corneil <cfc@ssb.no>"]
 license = "MIT"

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -91,7 +91,9 @@ class StatbankClient(StatbankAuth):
         if isinstance(date, str):
             self.date: dt.datetime = dt.datetime.strptime(date, "%Y-%m-%d").astimezone(
                 OSLO_TIMEZONE,
-            )
+            ) + dt.timedelta(
+                hours=1,
+            )  # Compensate for setting the timezone, stop publishing date from moving
         else:
             self.date = date
         self._validate_date()
@@ -178,7 +180,9 @@ class StatbankClient(StatbankAuth):
                 dt.datetime.min.time(),
             )
         elif isinstance(date, str):
-            date_date = dt.datetime.strptime(date, "%Y-%m-%d").astimezone(OSLO_TIMEZONE)
+            date_date = dt.datetime.strptime(date, "%Y-%m-%d").astimezone(
+                OSLO_TIMEZONE,
+            ) + dt.timedelta(hours=1)
         elif isinstance(date, dt.datetime):
             date_date = date
         else:
@@ -190,7 +194,7 @@ class StatbankClient(StatbankAuth):
         self._validate_date()
         logger.info("Publishing date set to: %s", self.date)
         self.log.append(
-            f"Date set to {self.date.isoformat('T', 'seconds')} at {dt.datetime.now().astimezone(OSLO_TIMEZONE).isoformat('T', 'seconds')}",
+            f"Date set to {self.date.isoformat('T', 'seconds')} at {(dt.datetime.now().astimezone(OSLO_TIMEZONE) + dt.timedelta(hours=1)).isoformat('T', 'seconds')}",
         )
 
     # Descriptions
@@ -211,7 +215,7 @@ class StatbankClient(StatbankAuth):
         """
         self._validate_params_action(tableid)
         self.log.append(
-            f"Getting description for tableid {tableid} at {dt.datetime.now().astimezone(OSLO_TIMEZONE,).isoformat('T', 'seconds')}",
+            f"Getting description for tableid {tableid} at {(dt.datetime.now().astimezone(OSLO_TIMEZONE,) + dt.timedelta(hours=1)).isoformat('T', 'seconds')}",
         )
         return StatbankUttrekksBeskrivelse(
             tableid=tableid,
@@ -278,7 +282,7 @@ class StatbankClient(StatbankAuth):
         )
         validation_errors = validator.validate(dfs)
         self.log.append(
-            f"Validated data for tableid {tableid} at {dt.datetime.now().astimezone(OSLO_TIMEZONE).isoformat('T', 'seconds')}",
+            f"Validated data for tableid {tableid} at {(dt.datetime.now().astimezone(OSLO_TIMEZONE) + dt.timedelta(hours=1)).isoformat('T', 'seconds')}",
         )
         return validation_errors
 
@@ -300,7 +304,7 @@ class StatbankClient(StatbankAuth):
         """
         self._validate_params_action(tableid)
         self.log.append(
-            f"Transferring tableid {tableid} at {dt.datetime.now().astimezone(OSLO_TIMEZONE).isoformat('T', 'seconds')}",
+            f"Transferring tableid {tableid} at {(dt.datetime.now().astimezone(OSLO_TIMEZONE) + dt.timedelta(hours=1)).isoformat('T', 'seconds')}",
         )
         return StatbankTransfer(
             dfs,

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -74,7 +74,9 @@ class StatbankClient(StatbankAuth):
         cc: str = "",
         bcc: str = "",
         overwrite: bool = True,
-        approve: Approve = APPROVE_DEFAULT_JIT,  # Changing back to 2, after wish from Rakel Gading
+        approve: (
+            int | str | Approve
+        ) = APPROVE_DEFAULT_JIT,  # Changing back to 2, after wish from Rakel Gading
         check_username_password: bool = True,
     ) -> None:
         """Initialize the client, storing password etc. on the client."""
@@ -83,7 +85,12 @@ class StatbankClient(StatbankAuth):
         self.cc = cc
         self.bcc = bcc
         self.overwrite = overwrite
-        self.approve = approve
+        if isinstance(approve, int):
+            self.approve: Approve = Approve(approve)
+        if isinstance(approve, str):
+            self.approve = getattr(Approve, approve)
+        else:
+            self.approve = approve
         self.check_username_password = check_username_password
         self._validate_params_init()
         self.__headers = self._build_headers()

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -87,10 +87,13 @@ class StatbankClient(StatbankAuth):
         self.overwrite = overwrite
         if isinstance(approve, int):
             self.approve: Approve = Approve(approve)
-        if isinstance(approve, str):
+        elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)
-        else:
+        elif isinstance(approve, Approve):
             self.approve = approve
+        else:
+            error_msg = f"Dont know how to handle approve of type {type(approve)}"
+            raise TypeError(error_msg)
         self.check_username_password = check_username_password
         self._validate_params_init()
         self.__headers = self._build_headers()

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -85,7 +85,7 @@ class StatbankClient(StatbankAuth):
         self.cc = cc
         self.bcc = bcc
         self.overwrite = overwrite
-        if isinstance(approve, int):
+        if isinstance(approve, int) and not isinstance(approve, Approve):
             self.approve: Approve = Approve(approve)
         elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -57,8 +57,9 @@ class StatbankClient(StatbankAuth):
             Defaults to the same as "cc"
         overwrite (bool): False = no overwrite
             True = overwrite
-        approve (Approve): 0 = manual approval
-            1 = automatic approval at transfer-time (immediately)
+        approve (Approve | str | int):
+            0 = MANUAL approval
+            1 = AUTOMATIC approval at transfer-time (immediately)
             2 = JIT (Just In Time), approval right before publishing time
         log (list[str]): Each "action" (method used) on the client is appended to the log.
             Nice to use for appending to your own logging after you are done,

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -25,6 +25,7 @@ from statbank.globals import OSLO_TIMEZONE
 from statbank.globals import STATBANK_TABLE_ID_LEN
 from statbank.globals import TOMORROW
 from statbank.globals import Approve
+from statbank.globals import approve_type_check
 from statbank.statbank_logger import logger
 from statbank.transfer import StatbankTransfer
 from statbank.uttrekk import StatbankUttrekksBeskrivelse
@@ -86,17 +87,7 @@ class StatbankClient(StatbankAuth):
         self.cc = cc
         self.bcc = bcc
         self.overwrite = overwrite
-        if isinstance(approve, int) and not isinstance(approve, Approve):
-            self.approve: Approve = Approve(approve)
-        elif isinstance(approve, str) and approve.isdigit():
-            self.approve = Approve(int(approve))
-        elif isinstance(approve, str):
-            self.approve = getattr(Approve, approve)
-        elif isinstance(approve, Approve):
-            self.approve = approve
-        else:
-            error_msg = f"Dont know how to handle approve of type {type(approve)}"  # type: ignore[unreachable]
-            raise TypeError(error_msg)
+        self.approve = approve_type_check(approve)
         self.check_username_password = check_username_password
         self._validate_params_init()
         self.__headers = self._build_headers()

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -25,7 +25,7 @@ from statbank.globals import OSLO_TIMEZONE
 from statbank.globals import STATBANK_TABLE_ID_LEN
 from statbank.globals import TOMORROW
 from statbank.globals import Approve
-from statbank.globals import approve_type_check
+from statbank.globals import _approve_type_check
 from statbank.statbank_logger import logger
 from statbank.transfer import StatbankTransfer
 from statbank.uttrekk import StatbankUttrekksBeskrivelse
@@ -87,7 +87,7 @@ class StatbankClient(StatbankAuth):
         self.cc = cc
         self.bcc = bcc
         self.overwrite = overwrite
-        self.approve = approve_type_check(approve)
+        self.approve = _approve_type_check(approve)
         self.check_username_password = check_username_password
         self._validate_params_init()
         self.__headers = self._build_headers()

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -87,12 +87,14 @@ class StatbankClient(StatbankAuth):
         self.overwrite = overwrite
         if isinstance(approve, int) and not isinstance(approve, Approve):
             self.approve: Approve = Approve(approve)
+        elif isinstance(approve, str) and approve.isdigit():
+            self.approve = Approve(int(approve))
         elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)
         elif isinstance(approve, Approve):
             self.approve = approve
         else:
-            error_msg = f"Dont know how to handle approve of type {type(approve)}"
+            error_msg = f"Dont know how to handle approve of type {type(approve)}"  # type: ignore[unreachable]
             raise TypeError(error_msg)
         self.check_username_password = check_username_password
         self._validate_params_init()

--- a/src/statbank/globals.py
+++ b/src/statbank/globals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import enum
 
@@ -11,6 +13,21 @@ class Approve(enum.IntEnum):
     """Automatic approval at transfer-time (immediately)."""
     JIT = 2
     """Just in time approval right before publishing time."""
+
+
+def _approve_type_check(approve: Approve | int | str) -> Approve:
+    if isinstance(approve, int) and not isinstance(approve, Approve):
+        result: Approve = Approve(approve)
+    elif isinstance(approve, str) and approve.isdigit():
+        result = Approve(int(approve))
+    elif isinstance(approve, str):
+        result = getattr(Approve, approve)
+    elif isinstance(approve, Approve):
+        result = approve
+    else:
+        error_msg = f"Dont know how to handle approve of type {type(approve)}"  # type: ignore[unreachable]
+        raise TypeError(error_msg)
+    return result
 
 
 OSLO_TIMEZONE = dt.timezone(dt.timedelta(hours=1))

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -90,10 +90,13 @@ class StatbankTransfer(StatbankAuth):
         self.overwrite = overwrite
         if isinstance(approve, int):
             self.approve: Approve = Approve(approve)
-        if isinstance(approve, str):
+        elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)
-        else:
+        elif isinstance(approve, Approve):
             self.approve = approve
+        else:
+            error_msg = f"Dont know how to handle approve of type {type(approve)}"
+            raise TypeError(error_msg)
         self.validation = validation
         self.__delay = delay
         self.oppdragsnummer: str = ""

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -18,6 +18,7 @@ from statbank.globals import APPROVE_DEFAULT_JIT
 from statbank.globals import OSLO_TIMEZONE
 from statbank.globals import SSB_TBF_LEN
 from statbank.globals import Approve
+from statbank.globals import _approve_type_check
 from statbank.statbank_logger import logger
 
 if TYPE_CHECKING:
@@ -88,17 +89,7 @@ class StatbankTransfer(StatbankAuth):
         self.data = data
         self.tableid = tableid
         self.overwrite = overwrite
-        if isinstance(approve, int) and not isinstance(approve, Approve):
-            self.approve: Approve = Approve(approve)
-        elif isinstance(approve, str) and approve.isdigit():
-            self.approve = Approve(int(approve))
-        elif isinstance(approve, str):
-            self.approve = getattr(Approve, approve)
-        elif isinstance(approve, Approve):
-            self.approve = approve
-        else:
-            error_msg = f"Dont know how to handle approve of type {type(approve)}"  # type: ignore[unreachable]
-            raise TypeError(error_msg)
+        self.approve = _approve_type_check(approve)
         self.validation = validation
         self.__delay = delay
         self.oppdragsnummer: str = ""

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -90,12 +90,14 @@ class StatbankTransfer(StatbankAuth):
         self.overwrite = overwrite
         if isinstance(approve, int) and not isinstance(approve, Approve):
             self.approve: Approve = Approve(approve)
+        elif isinstance(approve, str) and approve.isdigit():
+            self.approve = Approve(int(approve))
         elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)
         elif isinstance(approve, Approve):
             self.approve = approve
         else:
-            error_msg = f"Dont know how to handle approve of type {type(approve)}"
+            error_msg = f"Dont know how to handle approve of type {type(approve)}"  # type: ignore[unreachable]
             raise TypeError(error_msg)
         self.validation = validation
         self.__delay = delay

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -45,9 +45,9 @@ class StatbankTransfer(StatbankAuth):
         overwrite (bool):
             - False = no overwrite
             - True = overwrite
-        approve (Approve):
-            - 0 = manual approval
-            - 1 = automatic approval at transfer-time (immediately)
+        approve (Approve | str | int):
+            - 0 = MANUAL approval
+            - 1 = AUTOMATIC approval at transfer-time (immediately)
             - 2 = JIT (Just In Time), approval right before publishing time
         validation (bool):
             - True, if you want the python-validation code to run user-side.

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -88,7 +88,7 @@ class StatbankTransfer(StatbankAuth):
         self.data = data
         self.tableid = tableid
         self.overwrite = overwrite
-        if isinstance(approve, int):
+        if isinstance(approve, int) and not isinstance(approve, Approve):
             self.approve: Approve = Approve(approve)
         elif isinstance(approve, str):
             self.approve = getattr(Approve, approve)

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -183,7 +183,7 @@ class StatbankTransfer(StatbankAuth):
     def _set_date(self, date: dt | str | None = None) -> None:
         # At this point we want date to be a string?
         if date is None:
-            date = dt.now().astimezone(OSLO_TIMEZONE) + td(days=1)
+            date = dt.now().astimezone(OSLO_TIMEZONE) + td(days=1, hours=1)
         if isinstance(date, str):
             self.date: str = date
         else:
@@ -325,7 +325,7 @@ class StatbankTransfer(StatbankAuth):
         publish_date = dt.strptime(
             response_msg.split("Publiseringsdato '")[1].split("',")[0],
             "%d.%m.%Y %H:%M:%S",
-        ).astimezone(OSLO_TIMEZONE)
+        ).astimezone(OSLO_TIMEZONE) + dt.timedelta(hours=1)
         publish_hour = int(response_msg.split("Publiseringstid '")[1].split(":")[0])
         publish_minute = int(
             response_msg.split("Publiseringstid '")[1].split(":")[1].split("'")[0],

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -14,6 +14,7 @@ import pandas as pd
 import requests as r
 
 from statbank.auth import StatbankAuth
+from statbank.globals import APPROVE_DEFAULT_JIT
 from statbank.globals import OSLO_TIMEZONE
 from statbank.globals import SSB_TBF_LEN
 from statbank.globals import Approve
@@ -73,7 +74,7 @@ class StatbankTransfer(StatbankAuth):
         cc: str = "",
         bcc: str = "",
         overwrite: bool = True,
-        approve: Approve = Approve.MANUAL,
+        approve: int | str | Approve = APPROVE_DEFAULT_JIT,
         validation: bool = True,
         delay: bool = False,
         headers: dict[str, str] | None = None,
@@ -87,7 +88,12 @@ class StatbankTransfer(StatbankAuth):
         self.data = data
         self.tableid = tableid
         self.overwrite = overwrite
-        self.approve = approve
+        if isinstance(approve, int):
+            self.approve: Approve = Approve(approve)
+        if isinstance(approve, str):
+            self.approve = getattr(Approve, approve)
+        else:
+            self.approve = approve
         self.validation = validation
         self.__delay = delay
         self.oppdragsnummer: str = ""
@@ -325,7 +331,7 @@ class StatbankTransfer(StatbankAuth):
         publish_date = dt.strptime(
             response_msg.split("Publiseringsdato '")[1].split("',")[0],
             "%d.%m.%Y %H:%M:%S",
-        ).astimezone(OSLO_TIMEZONE) + dt.timedelta(hours=1)
+        ).astimezone(OSLO_TIMEZONE) + td(hours=1)
         publish_hour = int(response_msg.split("Publiseringstid '")[1].split(":")[0])
         publish_minute = int(
             response_msg.split("Publiseringstid '")[1].split(":")[1].split("'")[0],

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -230,8 +230,8 @@ def test_transfer_approve_wrong_format(
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
     test_build_user_agent.return_value = fake_build_user_agent()
-    with pytest.raises(ValueError, match="approve") as _:
-        StatbankTransfer(fake_data(), "10000", fake_user(), approve="1")
+    with pytest.raises(TypeError, match="approve") as _:
+        StatbankTransfer(fake_data(), "10000", fake_user(), approve={"1"})
 
 
 def test_repr_transfer(transfer_success: StatbankTransfer):

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -390,7 +390,7 @@ def test_client_set_date_int_raises(client_fake: StatbankClient):
 
 def test_client_set_date_datetime(client_fake: StatbankClient):
     client_fake.set_publish_date(
-        datetime.now().astimezone(OSLO_TIMEZONE),
+        datetime.now().astimezone(OSLO_TIMEZONE) + datetime.timedelta(hours=1),
     )
     assert "Date set to " in client_fake.log[-1]
 

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -234,6 +234,38 @@ def test_transfer_approve_wrong_format(
         StatbankTransfer(fake_data(), "10000", fake_user(), approve={"1"})
 
 
+@suppress_type_checks
+@mock.patch.object(StatbankTransfer, "_make_transfer_request")
+@mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_build_user_agent")
+def test_transfer_approve_int_intstr_str(
+    test_build_user_agent: Callable,
+    test_transfer_encrypt: Callable,
+    test_transfer_make_request: Callable,
+):
+    test_transfer_make_request.return_value = fake_post_response_transfer_successful()
+    test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_build_user_agent.return_value = fake_build_user_agent()
+    assert StatbankTransfer(
+        fake_data(),
+        "10000",
+        fake_user(),
+        approve=1,
+    ).oppdragsnummer.isdigit()
+    assert StatbankTransfer(
+        fake_data(),
+        "10000",
+        fake_user(),
+        approve="1",
+    ).oppdragsnummer.isdigit()
+    assert StatbankTransfer(
+        fake_data(),
+        "10000",
+        fake_user(),
+        approve="MANUAL",
+    ).oppdragsnummer.isdigit()
+
+
 def test_repr_transfer(transfer_success: StatbankTransfer):
     assert "StatbankTransfer" in transfer_success.__repr__()
 

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from datetime import timedelta as td
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -390,7 +391,7 @@ def test_client_set_date_int_raises(client_fake: StatbankClient):
 
 def test_client_set_date_datetime(client_fake: StatbankClient):
     client_fake.set_publish_date(
-        datetime.now().astimezone(OSLO_TIMEZONE) + datetime.timedelta(hours=1),
+        datetime.now().astimezone(OSLO_TIMEZONE) + td(hours=1),
     )
     assert "Date set to " in client_fake.log[-1]
 

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -318,7 +318,7 @@ def test_client_approve_wrong_datatype(
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
     test_build_user_agent.return_value = fake_build_user_agent()
-    with pytest.raises(ValueError, match="approve") as _:
+    with pytest.raises(TypeError, match="handle approve") as _:
         StatbankClient(fake_user(), approve=[1], check_username_password=False)
 
 

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -319,7 +319,7 @@ def test_client_approve_wrong_datatype(
     encrypt_fake.return_value = fake_post_response_key_service()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(ValueError, match="approve") as _:
-        StatbankClient(fake_user(), approve="1", check_username_password=False)
+        StatbankClient(fake_user(), approve=[1], check_username_password=False)
 
 
 @suppress_type_checks


### PR DESCRIPTION
Bug i dapla-statbank-client v1.1.0, denne PRen fikse bugen og oppgraderer til v1.1.1

Pga. implementering av tidssone på datoer i pakken, så blir publiseringsdato flyttet frem ett døgn ift. parametrene som er satt på v.1.1.0 av pakken. Bugen finnes kun i den versjonen

Funnet av @vilderov 