### PR TITLE
Lastebruker as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ ssb-project build
 Make a notebook with the project's kernel, try this code to verify that you can "log in":
 ```python
 from statbank import StatbankClient
-stat_client = StatbankClient(loaduser = "LASTEBRUKER")
+stat_client = StatbankClient()
 # Change LASTEBRUKER to your load-statbank-username
 # Fill out password
 # Default publishing-date is TOMORROW
 print(stat_client)
 # Printing will show you all the default settings on the client.
-# You can change for example date by specifying it: StatbankClient(loaduser = "LASTEBRUKER", date="2023-02-16")
+# You can change for example date by specifying it: StatbankClient(date="2023-02-16")
 ```
 
 Be aware that from the **dapla-staging environment** you will be sending to statbank-TEST-database, your changes will not be published. For this you need the "test-password", which is for the same user (lastebruker), but different from the ordinary password (lastepassord). If you are missing the test-password, have the statbank-team send it to you for your loaduser. If you are in the main dapla-jupyterlab (prod), you **WILL** publish to statbanken, in the PROD database. So pay extra attention to the **publishing-date** when in dapla-main-prod-jupyterlab. And be aware of which password you are entering, based on your environment. [To see data actually published to the test-database, you can use this link if you work at SSB.](https://i.test.ssb.no/pxwebi/pxweb/no/test_24v_intern/)

--- a/demo/01_enkleste_bruk.ipynb
+++ b/demo/01_enkleste_bruk.ipynb
@@ -68,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "client = StatbankClient(loaduser=\"LAST360\")"
+    "client = StatbankClient()"
    ]
   },
   {

--- a/demo/02_bruke_filbeskrivelse.ipynb
+++ b/demo/02_bruke_filbeskrivelse.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "client = StatbankClient(loaduser=\"LAST360\")"
+    "client = StatbankClient()"
    ]
   },
   {

--- a/demo/03_alleparametre_datewidget.ipynb
+++ b/demo/03_alleparametre_datewidget.ipynb
@@ -26,8 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = StatbankClient(loaduser=\"LAST360\",\n",
-    "                        #date=\"2023-02-21\",\n",
+    "client = StatbankClient(#date=\"2023-02-21\",\n",
     "                        shortuser=\"cfc\",\n",
     "                        cc=\"thu\",\n",
     "                        bcc=\"tir\",\n",

--- a/demo/fillna_dict_dev.ipynb
+++ b/demo/fillna_dict_dev.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "client = StatbankClient(loaduser=\"LAST360\")"
+    "client = StatbankClient()"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-statbank-client"
-version = "1.1.2"
+version = "1.2.0"
 description = "Handles data transfer Statbank <-> Dapla for Statistics Norway"
 authors = ["Statistics Norway", "Carl F. Corneil <cfc@ssb.no>"]
 license = "MIT"

--- a/src/statbank/auth.py
+++ b/src/statbank/auth.py
@@ -69,18 +69,14 @@ class StatbankAuth:
         return user_agent + r.utils.default_headers()["User-agent"]
 
     def _build_auth(self) -> str:
-        response = self._encrypt_request()
-        try:
-            username_encryptedpassword = (
-                bytes(
-                    getpass.getpass(f"Lastebruker ({self.check_database()}):"),
-                    "UTF-8",
-                )
-                + bytes(":", "UTF-8")
-                + bytes(json.loads(response.text)["message"], "UTF-8")
+        username_encryptedpassword = (
+            bytes(
+                getpass.getpass("Lastebruker:"),
+                "UTF-8",
             )
-        finally:
-            del response
+            + bytes(":", "UTF-8")
+            + bytes(json.loads(self._encrypt_request().text)["message"], "UTF-8")
+        )
         return "Basic " + base64.b64encode(username_encryptedpassword).decode("utf8")
 
     def _encrypt_request(self) -> r.Response:

--- a/src/statbank/auth.py
+++ b/src/statbank/auth.py
@@ -29,7 +29,6 @@ class StatbankAuth:
 
         This is for typing with Mypy.
         """
-        self.loaduser: str
 
     def _build_headers(self) -> dict[str, str]:
         return {
@@ -73,7 +72,10 @@ class StatbankAuth:
         response = self._encrypt_request()
         try:
             username_encryptedpassword = (
-                bytes(self.loaduser, "UTF-8")
+                bytes(
+                    getpass.getpass(f"Lastebruker ({self.check_database()}):"),
+                    "UTF-8",
+                )
                 + bytes(":", "UTF-8")
                 + bytes(json.loads(response.text)["message"], "UTF-8")
             )

--- a/src/statbank/auth.py
+++ b/src/statbank/auth.py
@@ -71,7 +71,7 @@ class StatbankAuth:
     def _build_auth(self) -> str:
         username_encryptedpassword = (
             bytes(
-                getpass.getpass("Lastebruker:"),
+                self._get_user(),
                 "UTF-8",
             )
             + bytes(":", "UTF-8")
@@ -79,7 +79,11 @@ class StatbankAuth:
         )
         return "Basic " + base64.b64encode(username_encryptedpassword).decode("utf8")
 
-    def _encrypt_request(self) -> r.Response:
+    @staticmethod
+    def _get_user() -> str:
+        return getpass.getpass("Lastebruker:")
+
+    def _encrypt_request(self) -> tuple[str, r.Response]:
         db = self.check_database()
         if AuthClient.is_ready():
             headers = {

--- a/src/statbank/auth.py
+++ b/src/statbank/auth.py
@@ -83,7 +83,7 @@ class StatbankAuth:
     def _get_user() -> str:
         return getpass.getpass("Lastebruker:")
 
-    def _encrypt_request(self) -> tuple[str, r.Response]:
+    def _encrypt_request(self) -> r.Response:
         db = self.check_database()
         if AuthClient.is_ready():
             headers = {

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -44,8 +44,6 @@ class StatbankClient(StatbankAuth):
     - get published data from the external or internal API of statbanken: apidata_all() / apidata()
 
     Attributes:
-        loaduser (str): Username for Statbanken, not the same as "tbf"
-            or "common personal username" in other SSB-systems
         date (str): Date for publishing the transfer. Shape should be "yyyy-mm-dd",
             like "2022-01-01".
             Statbanken only allows publishing four months into the future?
@@ -70,7 +68,6 @@ class StatbankClient(StatbankAuth):
 
     def __init__(  # noqa: PLR0913
         self,
-        loaduser: str = "",
         date: str | dt.datetime = TOMORROW,
         shortuser: str = "",
         cc: str = "",
@@ -82,7 +79,6 @@ class StatbankClient(StatbankAuth):
         check_username_password: bool = True,
     ) -> None:
         """Initialize the client, storing password etc. on the client."""
-        self.loaduser = loaduser
         self.shortuser = shortuser
         self.cc = cc
         self.bcc = bcc
@@ -114,7 +110,7 @@ class StatbankClient(StatbankAuth):
     # Representation
     def __str__(self) -> str:
         """Print a human readable text of the clients attributes."""
-        return f"""StatbankClient for user {self.loaduser}
+        return f"""StatbankClient
         Publishing at {self.date}
         Shortuser {self.shortuser}
         Sending mail to {self.cc}
@@ -129,7 +125,7 @@ class StatbankClient(StatbankAuth):
 
     def __repr__(self) -> str:
         """Represent the class with the necessary argument to replicate."""
-        result = f'StatbankClient(loaduser = "{self.loaduser}"'
+        result = "StatbankClient("
         if self.date != TOMORROW:
             result += f', date = "{self.date.isoformat("T", "seconds")}")'
         if self.shortuser:
@@ -226,7 +222,6 @@ class StatbankClient(StatbankAuth):
         )
         return StatbankUttrekksBeskrivelse(
             tableid=tableid,
-            loaduser=self.loaduser,
             headers=self.__headers,
         )
 
@@ -283,7 +278,6 @@ class StatbankClient(StatbankAuth):
         self._validate_params_action(tableid)
         validator = StatbankUttrekksBeskrivelse(
             tableid=tableid,
-            loaduser=self.loaduser,
             raise_errors=raise_errors,
             headers=self.__headers,
         )
@@ -316,7 +310,6 @@ class StatbankClient(StatbankAuth):
         return StatbankTransfer(
             dfs,
             tableid=tableid,
-            loaduser=self.loaduser,
             headers=self.__headers,
             shortuser=self.shortuser,
             date=self.date,
@@ -435,9 +428,6 @@ class StatbankClient(StatbankAuth):
 
     def _validate_params_init(self) -> None:
         """Validates many of the parameters sent in on client-initialization."""
-        if not self.loaduser or not isinstance(self.loaduser, str):
-            error_msg = "Please pass in a string for loaduser."
-            raise TypeError(error_msg)
         if not self.shortuser:
             self.shortuser = self._get_user_tbf()
         if not self.cc:

--- a/src/statbank/client.py
+++ b/src/statbank/client.py
@@ -89,11 +89,18 @@ class StatbankClient(StatbankAuth):
         self.__headers = self._build_headers()
         self.log: list[str] = []
         if isinstance(date, str):
-            self.date: dt.datetime = dt.datetime.strptime(date, "%Y-%m-%d").astimezone(
-                OSLO_TIMEZONE,
-            ) + dt.timedelta(
-                hours=1,
-            )  # Compensate for setting the timezone, stop publishing date from moving
+            try:
+                self.date: dt.datetime = dt.datetime.strptime(
+                    date,
+                    "%Y-%m-%d",
+                ).astimezone(
+                    OSLO_TIMEZONE,
+                ) + dt.timedelta(
+                    hours=1,
+                )  # Compensate for setting the timezone, stop publishing date from moving
+            except ValueError as e:
+                error_msg = f"Loaduser parameter removed, please do not use it in your code. OR: {e}"
+                raise ValueError(error_msg) from e
         else:
             self.date = date
         self._validate_date()

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -34,8 +34,6 @@ class StatbankTransfer(StatbankAuth):
             the uttakksbeskrivelse.
             Dict-shape can be retrieved and validated before transfer with the
             Uttakksbeskrivelses-class.
-        loaduser (str): Username for Statbanken, not the same as "shortuser" or
-            "common personal username" in other SSB-systems
         tableid (str): The numeric id of the table, matching the one found on the website.
             Should be a 5-length numeric-string. Alternatively it should be possible to send in the "hovedtabellnavn" instead of the tableid.
         shortuser (str): The abbrivation of username at ssb. Three letters, like "cfc"
@@ -69,7 +67,6 @@ class StatbankTransfer(StatbankAuth):
         self,
         data: dict[str, pd.DataFrame],
         tableid: str = "",
-        loaduser: str = "",
         shortuser: str = "",
         date: dt | str | None = None,
         cc: str = "",
@@ -84,7 +81,7 @@ class StatbankTransfer(StatbankAuth):
 
         May run the validations from the StatbankValidation class before the transfer.
         """
-        self._set_user_attrs(loaduser=loaduser, shortuser=shortuser, cc=cc, bcc=bcc)
+        self._set_user_attrs(shortuser=shortuser, cc=cc, bcc=bcc)
         self._set_date(date=date)
         self.data = data
         self.tableid = tableid
@@ -141,7 +138,7 @@ class StatbankTransfer(StatbankAuth):
 
     def __str__(self) -> str:
         """Print a string with the status of the transfer."""
-        first_line = f"Overføring for statbanktabell {self.tableid}.\nloaduser: {self.loaduser}.\n"
+        first_line = f"Overføring for statbanktabell {self.tableid}.\n"
         if self.delay:
             result = f"""{first_line}Ikke overført enda."""
         else:
@@ -150,7 +147,7 @@ class StatbankTransfer(StatbankAuth):
 
     def __repr__(self) -> str:
         """Get a representation of how to recreate the object using parameters."""
-        return f'StatbankTransfer([data], tableid="{self.tableid}", loaduser="{self.loaduser}")'
+        return f'StatbankTransfer([data], tableid="{self.tableid}")'
 
     @property
     def delay(self) -> bool:
@@ -159,17 +156,10 @@ class StatbankTransfer(StatbankAuth):
 
     def _set_user_attrs(
         self,
-        loaduser: str = "",
         shortuser: str = "",
         cc: str = "",
         bcc: str = "",
     ) -> None:
-        if isinstance(loaduser, str) and loaduser != "":
-            self.loaduser = loaduser
-        else:
-            error_msg = "You must set loaduser as a parameter"
-            raise ValueError(error_msg)
-
         if shortuser:
             self.shortuser = shortuser
         else:

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -84,7 +84,7 @@ class StatbankTransfer(StatbankAuth):
         self._set_user_attrs(shortuser=shortuser, cc=cc, bcc=bcc)
         self._set_date(date=date)
         self.data = data
-        if not isinstance(tableid, str) or tableid.isdigit():
+        if not isinstance(tableid, str) or not tableid.isdigit():
             error_msg = "Loaduser is no longer a parameter, make sure the tableid parameter is a string of digits."
             raise ValueError(error_msg)
         self.tableid = tableid

--- a/src/statbank/transfer.py
+++ b/src/statbank/transfer.py
@@ -84,6 +84,9 @@ class StatbankTransfer(StatbankAuth):
         self._set_user_attrs(shortuser=shortuser, cc=cc, bcc=bcc)
         self._set_date(date=date)
         self.data = data
+        if not isinstance(tableid, str) or tableid.isdigit():
+            error_msg = "Loaduser is no longer a parameter, make sure the tableid parameter is a string of digits."
+            raise ValueError(error_msg)
         self.tableid = tableid
         self.overwrite = overwrite
         self.approve = _approve_type_check(approve)

--- a/src/statbank/uttrekk.py
+++ b/src/statbank/uttrekk.py
@@ -252,7 +252,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         if raise_errors and validation_errors:
             raise StatbankValidateError(list(validation_errors.values()))
         logger.info(
-            "validation finished (if nothing is logged over debug level, everything should be fine.)",
+            "validation finished (if nothing is logged over info level, everything should be fine.)",
         )
         return validation_errors
 

--- a/src/statbank/uttrekk.py
+++ b/src/statbank/uttrekk.py
@@ -62,6 +62,11 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         self.url = self._build_urls()["uttak"]
         self.time_retrieved = ""
         self.tableid = tableid
+        if not isinstance(raise_errors, bool):
+            error_msg = (
+                "raise_errors must be a bool, the loaduser parameter has been removed."
+            )
+            raise TypeError(error_msg)
         self.raise_errors = raise_errors
         self.tablename = ""
         self.subtables: dict[str, str] = {}

--- a/src/statbank/uttrekk.py
+++ b/src/statbank/uttrekk.py
@@ -36,7 +36,6 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
 
 
     Attributes:
-        loaduser (str): Username for Statbanken, not the same as "tbf" or "common personal username" in other SSB-systems
         url (str): Main url for transfer
         time_retrieved  (str): Time of getting the Uttrekksbeskrivelse
         tableid (str): Originally the ID of the main table, which to get the
@@ -56,12 +55,10 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
     def __init__(
         self,
         tableid: str,
-        loaduser: str,
         raise_errors: bool = False,
         headers: dict[str, str] | None = None,
     ) -> None:
         """Makes a request to the Statbank-API, populates the objects attributes with parts of the return values."""
-        self.loaduser = loaduser
         self.url = self._build_urls()["uttak"]
         self.time_retrieved = ""
         self.tableid = tableid
@@ -114,7 +111,6 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         variabel_text += f'\n"Ekspandert matrise/antall koder i kodelistene ganget med hverandre er: {mult_codelists}'
 
         return f"""Uttrekksbeskrivelse for statbanktabell {self.tableid}.
-        loaduser: {self.loaduser}.
 
         Hele filbeskrivelsen "rå" ligger under .filbeskrivelse
         Andre attributter:
@@ -124,7 +120,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
 
     def __repr__(self) -> str:
         """Return a string representation of how to instantiate this object again."""
-        return f'StatbankUttrekksBeskrivelse(tableid="{self.tableid}", loaduser="{self.loaduser}")'
+        return f'StatbankUttrekksBeskrivelse(tableid="{self.tableid}",)'
 
     def transferdata_template(
         self,

--- a/src/statbank/uttrekk.py
+++ b/src/statbank/uttrekk.py
@@ -63,7 +63,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         self.time_retrieved = ""
         self.tableid = tableid
         if not isinstance(raise_errors, bool):
-            error_msg = (
+            error_msg = (  # type: ignore[unreachable]
                 "raise_errors must be a bool, the loaduser parameter has been removed."
             )
             raise TypeError(error_msg)

--- a/tests/test_apidata.py
+++ b/tests/test_apidata.py
@@ -64,14 +64,17 @@ def fake_post_apidata() -> requests.Response:
 
 @pytest.fixture()
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
 def client_fake(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ) -> StatbankClient:
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
-    return StatbankClient(fake_user(), check_username_password=False)
+    return StatbankClient(check_username_password=False)
 
 
 @pytest.fixture()

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -575,6 +575,7 @@ def test_uttrekk_works_no_codelists(
     assert desc.tableid == "10000"
 
 
+@suppress_type_checks
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -103,81 +103,95 @@ def fake_build_user_agent():
 @pytest.fixture()
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_build_user_agent")
 def uttrekksbeskrivelse_success(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_encrypt: Callable,
     test_make_request: Callable,
 ):
     test_make_request.return_value = fake_get_response_uttrekksbeskrivelse_successful()
     test_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
-    return StatbankUttrekksBeskrivelse("10000", fake_user())
+    return StatbankUttrekksBeskrivelse("10000")
 
 
 @pytest.fixture()
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def transfer_success(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
-    return StatbankTransfer(fake_data(), "10000", fake_user())
+    return StatbankTransfer(fake_data(), "10000")
 
 
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_date_is_string(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
-    trans = StatbankTransfer(fake_data(), "10000", fake_user(), date="2050-01-01")
+    trans = StatbankTransfer(fake_data(), "10000", date="2050-01-01")
     assert trans.oppdragsnummer.isdigit()
 
 
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_date_is_invalid_string_raises(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(
         TypeError,
         match="Skriv inn datoformen for publisering som 1900-01-01",
     ) as _:
-        StatbankTransfer(fake_data(), "10000", fake_user(), date="205000-01-01")
+        StatbankTransfer(fake_data(), "10000", date="205000-01-01")
 
 
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_str_transfer_on_delay_and_after(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     trans = StatbankTransfer(
         fake_data(),
         "10000",
-        fake_user(),
         date="2050-01-01",
         delay=True,
     )
@@ -190,72 +204,77 @@ def test_str_transfer_on_delay_and_after(
 @suppress_type_checks
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_overwrite_wrong_format(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(TypeError, match="Sett overwrite") as _:
-        StatbankTransfer(fake_data(), "10000", fake_user(), overwrite=1)
+        StatbankTransfer(fake_data(), "10000", overwrite=1)
 
 
 @suppress_type_checks
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_approve_wrong_format(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(TypeError, match="approve") as _:
-        StatbankTransfer(fake_data(), "10000", fake_user(), approve={"1"})
+        StatbankTransfer(fake_data(), "10000", approve={"1"})
 
 
 @suppress_type_checks
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_approve_int_intstr_str(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     assert StatbankTransfer(
         fake_data(),
         "10000",
-        fake_user(),
         approve=1,
     ).oppdragsnummer.isdigit()
 
     assert StatbankTransfer(
         fake_data(),
         "10000",
-        fake_user(),
         approve="1",
     ).oppdragsnummer.isdigit()
 
     assert StatbankTransfer(
         fake_data(),
         "10000",
-        fake_user(),
         approve="MANUAL",
     ).oppdragsnummer.isdigit()
 
     params_dict: dict[str, str] = StatbankTransfer(  # noqa: SLF001
         fake_data(),
         "10000",
-        fake_user(),
         approve="MANUAL",
     )._build_params()
     for v in params_dict.values():
@@ -279,20 +298,22 @@ def test_transfer_cant_transfer_twice_raises(transfer_success: StatbankTransfer)
 
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_shortuser_wrong_raises(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(ValueError, match="trebokstavsforkortelse") as _:
         StatbankTransfer(
             fake_data(),
             "10000",
-            fake_user(),
             date="2050-01-01",
             shortuser="aa",
         )
@@ -300,23 +321,31 @@ def test_transfer_shortuser_wrong_raises(
 
 @pytest.fixture()
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
-def client_fake(test_build_user_agent: Callable, encrypt_fake: Callable):
-    encrypt_fake.return_value = fake_post_response_key_service()
-    test_build_user_agent.return_value = fake_build_user_agent()
-    return StatbankClient(fake_user(), check_username_password=False)
-
-
-@mock.patch.object(StatbankClient, "_encrypt_request")
-@mock.patch.object(StatbankClient, "_build_user_agent")
-def test_client_set_approve_overwrite(
+def client_fake(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
+    test_build_user_agent.return_value = fake_build_user_agent()
+    return StatbankClient(check_username_password=False)
+
+
+@mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
+@mock.patch.object(StatbankClient, "_build_user_agent")
+def test_client_set_approve_overwrite(
+    test_build_user_agent: Callable,
+    test_get_user: Callable,
+    encrypt_fake: Callable,
+):
+    encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     client = StatbankClient(
-        fake_user(),
         check_username_password=False,
         overwrite=False,
         approve=1,
@@ -327,41 +356,50 @@ def test_client_set_approve_overwrite(
 
 @suppress_type_checks
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
 def test_client_approve_wrong_datatype(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(TypeError, match="handle approve") as _:
-        StatbankClient(fake_user(), approve=[1], check_username_password=False)
+        StatbankClient(approve=[1], check_username_password=False)
 
 
 @suppress_type_checks
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
 def test_client_overwrite_wrong_datatype(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(TypeError, match="overwrite") as _:
-        StatbankClient(fake_user(), overwrite="1", check_username_password=False)
+        StatbankClient(overwrite="1", check_username_password=False)
 
 
 @suppress_type_checks
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
 def test_client_date_wrong_datatype(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     with pytest.raises(TypeError, match="Date must be a datetime") as _:
-        StatbankClient(fake_user(), check_username_password=False, date=1)
+        StatbankClient(check_username_password=False, date=1)
 
 
 def test_client_print(client_fake: StatbankClient):
@@ -375,14 +413,17 @@ def test_client_repr(client_fake: StatbankClient):
 
 
 @mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
 @mock.patch.object(StatbankClient, "_build_user_agent")
 def test_client_with_str_date(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     encrypt_fake: Callable,
 ):
     encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
-    client = StatbankClient(fake_user(), "2050-01-01", check_username_password=False)
+    client = StatbankClient("2050-01-01", check_username_password=False)
     assert isinstance(client.date, datetime)
 
 
@@ -420,15 +461,18 @@ def test_client_set_date_widget(client_fake: StatbankClient):
 
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_build_user_agent")
 def test_client_get_uttrekk(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_encrypt: Callable,
     test_make_request: Callable,
     client_fake: StatbankClient,
 ):
     test_make_request.return_value = fake_get_response_uttrekksbeskrivelse_successful()
     test_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     desc = client_fake.get_description("10000")
     assert desc.tableid == "10000"
@@ -436,9 +480,11 @@ def test_client_get_uttrekk(
 
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_build_user_agent")
-def test_client_validate_no_errors(
+def test_client_validate_no_errors(  # noqa: PLR0913
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_encrypt: Callable,
     test_make_request: Callable,
     client_fake: StatbankClient,
@@ -446,6 +492,7 @@ def test_client_validate_no_errors(
 ):
     test_make_request.return_value = fake_get_response_uttrekksbeskrivelse_successful()
     test_encrypt.return_value = (fake_post_response_key_service(),)
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     data = uttrekksbeskrivelse_success.round_data(fake_data())
     errors = client_fake.validate(data, "10000")
@@ -466,9 +513,11 @@ def test_client_get_uttrekk_tableid_wrong_length(client_fake: StatbankClient):
 
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")
 @mock.patch.object(StatbankUttrekksBeskrivelse, "_build_user_agent")
 def test_uttrekk_works_no_codelists(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_encrypt: Callable,
     test_make_request: Callable,
     client_fake: StatbankClient,
@@ -483,6 +532,7 @@ def test_uttrekk_works_no_codelists(
     )
     test_make_request.return_value = uttrekk
     test_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     desc = client_fake.get_description("10000")
     assert desc.tableid == "10000"
@@ -603,8 +653,8 @@ def test_transfer_no_auth_residuals(transfer_success: StatbankTransfer):
     # Do a search for the key, password, and ciphered auth in the returned object.
     # Important to remove any traces of these before object is handed to user
 
-    # Username should be in object (checks integrity of object, and validity of search)
-    assert len(search__dict__(transfer_success, fake_user(), keep={}))
+    # Tableid should be in object (checks integrity of object, and validity of search)
+    assert len(search__dict__(transfer_success, "10000", keep={}))
 
     # Make sure none of these are in the object for security
     assert len(search__dict__(transfer_success, fake_pass(), keep={})) == 0
@@ -651,14 +701,17 @@ def search__dict__(
 
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_client_transfer(
     test_build_user_agent: Callable,
+    test_get_user: Callable,
     test_transfer_encrypt: Callable,
     test_transfer_make_request: Callable,
     client_fake: StatbankClient,
 ):
     test_transfer_make_request.return_value = fake_post_response_transfer_successful()
     test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
     test_build_user_agent.return_value = fake_build_user_agent()
     client_fake.transfer(fake_data(), "10000")

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -133,21 +133,6 @@ def transfer_success(
 @mock.patch.object(StatbankTransfer, "_make_transfer_request")
 @mock.patch.object(StatbankTransfer, "_encrypt_request")
 @mock.patch.object(StatbankTransfer, "_build_user_agent")
-def test_transfer_no_loaduser_raises(
-    test_build_user_agent: Callable,
-    test_transfer_encrypt: Callable,
-    test_transfer_make_request: Callable,
-):
-    test_transfer_make_request.return_value = fake_post_response_transfer_successful()
-    test_transfer_encrypt.return_value = fake_post_response_key_service()
-    test_build_user_agent.return_value = fake_build_user_agent()
-    with pytest.raises(ValueError, match="loaduser") as _:
-        StatbankTransfer(fake_data(), "10000")
-
-
-@mock.patch.object(StatbankTransfer, "_make_transfer_request")
-@mock.patch.object(StatbankTransfer, "_encrypt_request")
-@mock.patch.object(StatbankTransfer, "_build_user_agent")
 def test_transfer_date_is_string(
     test_build_user_agent: Callable,
     test_transfer_encrypt: Callable,
@@ -320,19 +305,6 @@ def client_fake(test_build_user_agent: Callable, encrypt_fake: Callable):
     encrypt_fake.return_value = fake_post_response_key_service()
     test_build_user_agent.return_value = fake_build_user_agent()
     return StatbankClient(fake_user(), check_username_password=False)
-
-
-@suppress_type_checks
-@mock.patch.object(StatbankClient, "_encrypt_request")
-@mock.patch.object(StatbankClient, "_build_user_agent")
-def test_client_no_loaduser_set(
-    test_build_user_agent: Callable,
-    encrypt_fake: Callable,
-):
-    encrypt_fake.return_value = fake_post_response_key_service()
-    test_build_user_agent.return_value = fake_build_user_agent()
-    with pytest.raises(TypeError, match="loaduser") as _:
-        StatbankClient(1, check_username_password=False)
 
 
 @mock.patch.object(StatbankClient, "_encrypt_request")

--- a/tests/test_statbank.py
+++ b/tests/test_statbank.py
@@ -319,6 +319,28 @@ def test_transfer_shortuser_wrong_raises(
         )
 
 
+@mock.patch.object(StatbankTransfer, "_make_transfer_request")
+@mock.patch.object(StatbankTransfer, "_encrypt_request")
+@mock.patch.object(StatbankTransfer, "_get_user")
+@mock.patch.object(StatbankTransfer, "_build_user_agent")
+def test_transfer_loaduser_still(
+    test_build_user_agent: Callable,
+    test_get_user: Callable,
+    test_transfer_encrypt: Callable,
+    test_transfer_make_request: Callable,
+):
+    test_transfer_make_request.return_value = fake_post_response_transfer_successful()
+    test_transfer_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
+    test_build_user_agent.return_value = fake_build_user_agent()
+    with pytest.raises(ValueError, match="Loaduser") as _:
+        StatbankTransfer(
+            fake_data(),
+            fake_user(),
+            "10000",
+        )
+
+
 @pytest.fixture()
 @mock.patch.object(StatbankClient, "_encrypt_request")
 @mock.patch.object(StatbankClient, "_get_user")
@@ -425,6 +447,21 @@ def test_client_with_str_date(
     test_build_user_agent.return_value = fake_build_user_agent()
     client = StatbankClient("2050-01-01", check_username_password=False)
     assert isinstance(client.date, datetime)
+
+
+@mock.patch.object(StatbankClient, "_encrypt_request")
+@mock.patch.object(StatbankClient, "_get_user")
+@mock.patch.object(StatbankClient, "_build_user_agent")
+def test_client_loaduser_still(
+    test_build_user_agent: Callable,
+    test_get_user: Callable,
+    encrypt_fake: Callable,
+):
+    encrypt_fake.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
+    test_build_user_agent.return_value = fake_build_user_agent()
+    with pytest.raises(ValueError, match="Loaduser"):
+        StatbankClient(fake_user(), "2050-01-01", check_username_password=False)
 
 
 def test_client_date_picker_is_widget(client_fake: StatbankClient):
@@ -536,6 +573,25 @@ def test_uttrekk_works_no_codelists(
     test_build_user_agent.return_value = fake_build_user_agent()
     desc = client_fake.get_description("10000")
     assert desc.tableid == "10000"
+
+
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_make_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_encrypt_request")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_get_user")
+@mock.patch.object(StatbankUttrekksBeskrivelse, "_build_user_agent")
+def test_uttrekk_raises_on_raise_non_bool(
+    test_build_user_agent: Callable,
+    test_get_user: Callable,
+    test_encrypt: Callable,
+    test_make_request: Callable,
+):
+    uttrekk = fake_get_response_uttrekksbeskrivelse_successful()
+    test_make_request.return_value = uttrekk
+    test_encrypt.return_value = fake_post_response_key_service()
+    test_get_user.return_value = fake_user()
+    test_build_user_agent.return_value = fake_build_user_agent()
+    with pytest.raises(TypeError, match="oaduser"):
+        StatbankUttrekksBeskrivelse("10000", fake_user())
 
 
 def test_uttrekksbeskrivelse_has_kodelister(


### PR DESCRIPTION
This will potentially break some users code, and that is intentional. 
Loaduser moved to being an input-field on Auth instead of a parameter. 
This also contains a version bump to v1.2.0 because of this potentially breaking change.