### PR TITLE
Forbedrede feilmeldinger for apidata

### DIFF
--- a/src/statbank/api_exceptions.py
+++ b/src/statbank/api_exceptions.py
@@ -1,0 +1,14 @@
+class StatbankApiError(Exception):
+    """Base class for Statbank Api Errors."""
+
+
+class TooBigRequestError(StatbankApiError):
+    """Exception for request that is to big to handle for the Statbank Api.
+
+    The API is limited to 800,000 cells (incl. empty cells)
+    """
+
+class StatbankQueryError(StatbankApiError):
+    """Exception for invalid request."""
+
+

--- a/src/statbank/api_exceptions.py
+++ b/src/statbank/api_exceptions.py
@@ -8,9 +8,10 @@ class TooBigRequestError(StatbankApiError):
     The API is limited to 800,000 cells (incl. empty cells)
     """
 
+
 class StatbankParameterError(StatbankApiError):
     """Exception for invalid request."""
 
+
 class StatbankVariableSelectionError(StatbankApiError):
     """Exception for invalid variable selection."""
-

--- a/src/statbank/api_exceptions.py
+++ b/src/statbank/api_exceptions.py
@@ -8,7 +8,9 @@ class TooBigRequestError(StatbankApiError):
     The API is limited to 800,000 cells (incl. empty cells)
     """
 
-class StatbankQueryError(StatbankApiError):
+class StatbankParameterError(StatbankApiError):
     """Exception for invalid request."""
 
+class StatbankVariableSelectionError(StatbankApiError):
+    """Exception for invalid variable selection."""
 

--- a/src/statbank/apidata.py
+++ b/src/statbank/apidata.py
@@ -5,6 +5,7 @@ import urllib
 from collections import Counter
 from http import HTTPStatus
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import TypeVar
 
 import requests as r
@@ -13,7 +14,6 @@ from pyjstat import pyjstat
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
-    from typing import Any
 
     import pandas as pd
 
@@ -29,110 +29,6 @@ from .statbank_logger import logger
 
 STATBANK_TABLE_ID_LENGTH = 5
 T = TypeVar("T")
-
-
-def _list_up(sequence: Sequence[str], conjunction: str = "and") -> str:
-    if len(sequence) == 1:
-        return sequence[0]
-
-    return f"{', '.join(sequence[:-1])} {conjunction} {sequence[-1]}"
-
-
-def _find_duplicates(items: Iterable[T]) -> list[T]:
-    return [item for item, n in Counter(items).items() if n > 1]
-
-
-def read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> None:
-    """Raises an appropriate error."""
-    error_message: str | None
-
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        error_message = "Your query is too big. The API is limited to 800,000 cells (incl. empty cells)"
-        raise TooBigRequestError(error_message)
-
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        api_error_message = response.json().get("error", "")
-
-        match = re.match(
-            r"The request for variable '(?P<variable>.+)' has an error\. Please check your query\.",
-            api_error_message,
-        )
-
-        if match:
-            variable = match["variable"]
-            error_message = check_selection(variable, id_or_url, query)
-            if not error_message:
-                error_message = (
-                    f'Your query failed with the error message: "{api_error_message}"'
-                )
-            raise StatbankVariableSelectionError(error_message)
-
-        error_message = f'Your query failed with the error message: "{api_error_message}"'
-        raise StatbankParameterError(error_message)
-
-    response.raise_for_status()
-
-
-def check_selection(
-    variable: str,
-    id_or_url: str,
-    query: QueryWholeType,
-) -> str | None:
-    """Checks for common errors in your query selection, and returns a error message.
-
-    When the query fails with the message "The request for variable ... has an error,"
-    check that the selection don't contains duplicate and invalid values against the metadata and
-    check that the filter is set to "all" when selecting with a wildcard (*).
-    Metadata for aggregations are not available, so we can't inspect selection with agg and agg_single filters.
-    Errors with "top" and "all" filter always fail with "parameter error", so we don't validate them here.
-    """
-    query_part = next(filter(lambda part: part["code"] == variable, query["query"]))
-    query_selection = query_part["selection"]
-
-    match = re.fullmatch(
-        r"(?P<filtertype>(item)|(vs|agg|agg_single))(?(3):(?P<aggregering>.+))",
-        query_selection["filter"],
-    )
-
-    if match is None:
-        return f'The filter don\'t match one of the types "item", "all", "top", "vs:", "agg:", "agg_single:", for variable {variable}.'
-
-    filter_type = match["filtertype"]
-
-    duplicates = _find_duplicates(query_selection["values"])
-    if len(duplicates) > 0:
-        return (
-            f"The value(s) {_list_up(duplicates)} is duplicated for variable {variable}"
-        )
-
-    if any("*" in values for values in query_selection["values"]):
-        return (
-            f"One of the values for the variable {variable} contains a wildcard character (*)."
-            'If you wish to select several or all values with a wildcard, "filter" must be set to "all"'
-        )
-
-    if filter_type in ("agg", "agg_single"):
-        return (
-            "A value is probably invalid for variable {variable}, but an aggregation is used,"
-            "and metadata for aggregations is not available, so it is not possible to determine witch."
-        )
-
-    meta = apimetadata(id_or_url)
-
-    variable_meta = next(
-        filter(lambda part: part["code"] == variable, meta["variables"]),
-    )
-
-    invalid_values = [
-        value
-        for value in query_selection["values"]
-        if value not in variable_meta["values"]
-    ]
-
-    if len(invalid_values) > 0:
-        return f"Invalid value(s) {_list_up(invalid_values)} have been specified for the variable {variable}"
-
-    return None
 
 
 def apidata(
@@ -175,7 +71,7 @@ def apidata(
     # Spør APIet om å få resultatet med requests-biblioteket
     resultat = r.post(url, json=payload_now, timeout=10)
     if not resultat.ok:
-        read_error(id_or_url, payload_now, resultat)
+        _read_error(id_or_url, payload_now, resultat)
 
     # Putt teksten i resultatet inn i ett pyjstat-datasett-objekt
     dataset_pyjstat = pyjstat.Dataset.read(resultat.text)
@@ -316,3 +212,110 @@ def apidata_rotate(
         values=val,
         columns=[i for i in df.columns if i not in (ind, val)],
     )
+
+
+# Error handeling and HTTP-return code interpretations follow
+def _list_up(sequence: Sequence[str], conjunction: str = "and") -> str:
+    if len(sequence) == 1:
+        return sequence[0]
+
+    return f"{', '.join(sequence[:-1])} {conjunction} {sequence[-1]}"
+
+
+def _find_duplicates(items: Iterable[T]) -> list[T]:
+    return [item for item, n in Counter(items).items() if n > 1]
+
+
+def _read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> None:
+    """Raises an appropriate error."""
+    error_message: str | None
+
+    if response.status_code == HTTPStatus.FORBIDDEN:
+        error_message = "Your query is too big. The API is limited to 800,000 cells (incl. empty cells)"
+        raise TooBigRequestError(error_message)
+
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        api_error_message = response.json().get("error", "")
+
+        match = re.match(
+            r"The request for variable '(?P<variable>.+)' has an error\. Please check your query\.",
+            api_error_message,
+        )
+
+        if match:
+            variable = match["variable"]
+            error_message = _check_selection(variable, id_or_url, query)
+            if not error_message:
+                error_message = (
+                    f'Your query failed with the error message: "{api_error_message}"'
+                )
+            raise StatbankVariableSelectionError(error_message)
+
+        error_message = (
+            f'Your query failed with the error message: "{api_error_message}"'
+        )
+        raise StatbankParameterError(error_message)
+
+    response.raise_for_status()
+
+
+def _check_selection(
+    variable: str,
+    id_or_url: str,
+    query: QueryWholeType,
+) -> str | None:
+    """Checks for common errors in your query selection, and returns a error message.
+
+    When the query fails with the message "The request for variable ... has an error,"
+    check that the selection don't contains duplicate and invalid values against the metadata and
+    check that the filter is set to "all" when selecting with a wildcard (*).
+    Metadata for aggregations are not available, so we can't inspect selection with agg and agg_single filters.
+    Errors with "top" and "all" filter always fail with "parameter error", so we don't validate them here.
+    """
+    query_part = next(filter(lambda part: part["code"] == variable, query["query"]))
+    query_selection = query_part["selection"]
+
+    match = re.fullmatch(
+        r"(?P<filtertype>(item)|(vs|agg|agg_single))(?(3):(?P<aggregering>.+))",
+        query_selection["filter"],
+    )
+
+    if match is None:
+        return f'The filter don\'t match one of the types "item", "all", "top", "vs:", "agg:", "agg_single:", for variable {variable}.'
+
+    filter_type = match["filtertype"]
+
+    duplicates = _find_duplicates(query_selection["values"])
+    if len(duplicates) > 0:
+        return (
+            f"The value(s) {_list_up(duplicates)} is duplicated for variable {variable}"
+        )
+
+    if any("*" in values for values in query_selection["values"]):
+        return (
+            f"One of the values for the variable {variable} contains a wildcard character (*)."
+            'If you wish to select several or all values with a wildcard, "filter" must be set to "all"'
+        )
+
+    if filter_type in ("agg", "agg_single"):
+        return (
+            "A value is probably invalid for variable {variable}, but an aggregation is used,"
+            "and metadata for aggregations is not available, so it is not possible to determine witch."
+        )
+
+    meta = apimetadata(id_or_url)
+
+    variable_meta = next(
+        filter(lambda part: part["code"] == variable, meta["variables"]),
+    )
+
+    invalid_values = [
+        value
+        for value in query_selection["values"]
+        if value not in variable_meta["values"]
+    ]
+
+    if len(invalid_values) > 0:
+        return f"Invalid value(s) {_list_up(invalid_values)} have been specified for the variable {variable}"
+
+    return None

--- a/src/statbank/apidata.py
+++ b/src/statbank/apidata.py
@@ -30,7 +30,8 @@ from .statbank_logger import logger
 STATBANK_TABLE_ID_LENGTH = 5
 T = TypeVar("T")
 
-def _list_up(sequence: Sequence[Any], conjunction: str = "and") -> str:
+
+def _list_up(sequence: Sequence[str], conjunction: str = "and") -> str:
     if len(sequence) == 1:
         return sequence[0]
 

--- a/src/statbank/apidata.py
+++ b/src/statbank/apidata.py
@@ -42,7 +42,6 @@ def _find_duplicates(items: Iterable[T]) -> list[T]:
     return [item for item, n in Counter(items).items() if n > 1]
 
 
-
 def read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> None:
     """Raises an appropriate error."""
     if response.status_code == HTTPStatus.FORBIDDEN:
@@ -61,7 +60,9 @@ def read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> N
             variable = match["variable"]
             error_message = check_selection(variable, id_or_url, query)
             if not error_message:
-                error_message = f'Your query failed with the error message: "{error_message}"'
+                error_message = (
+                    f'Your query failed with the error message: "{error_message}"'
+                )
             raise StatbankVariableSelectionError(error_message)
 
         error_message = f'Your query failed with the error message: "{error_message}"'
@@ -71,7 +72,9 @@ def read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> N
 
 
 def check_selection(
-    variable: str, id_or_url: str, query: QueryWholeType,
+    variable: str,
+    id_or_url: str,
+    query: QueryWholeType,
 ) -> str | None:
     """Checks for common errors in your query selection, and returns a error message.
 
@@ -96,7 +99,9 @@ def check_selection(
 
     duplicates = _find_duplicates(query_selection["values"])
     if len(duplicates) > 0:
-        return f"The value(s) {_list_up(duplicates)} is duplicated for variable {variable}"
+        return (
+            f"The value(s) {_list_up(duplicates)} is duplicated for variable {variable}"
+        )
 
     if any("*" in values for values in query_selection["values"]):
         return (
@@ -123,9 +128,7 @@ def check_selection(
     ]
 
     if len(invalid_values) > 0:
-        return (
-            f"Invalid value(s) {_list_up(invalid_values)} have been specified for the variable {variable}"
-        )
+        return f"Invalid value(s) {_list_up(invalid_values)} have been specified for the variable {variable}"
 
     return None
 

--- a/src/statbank/apidata.py
+++ b/src/statbank/apidata.py
@@ -20,7 +20,8 @@ if TYPE_CHECKING:
     from .api_types import QueryPartType
     from .api_types import QueryWholeType
 
-from .api_exceptions import StatbankQueryError
+from .api_exceptions import StatbankParameterError
+from .api_exceptions import StatbankVariableSelectionError
 from .api_exceptions import TooBigRequestError
 from .statbank_logger import logger
 
@@ -58,13 +59,12 @@ def read_error(id_or_url: str, query: QueryWholeType, response: r.Response) -> N
         if match:
             variable = match["variable"]
             error_message = check_selection(variable, id_or_url, query)
-        else:
-            error_message = None
+            if not error_message:
+                error_message = f'Your query failed with the error message: "{error_message}"'
+            raise StatbankVariableSelectionError(error_message)
 
-        if not error_message:
-            error_message = f'Your query failed with the error message "{error_message}"'
-
-        raise StatbankQueryError(error_message)
+        error_message = f'Your query failed with the error message: "{error_message}"'
+        raise StatbankParameterError(error_message)
 
     response.raise_for_status()
 

--- a/tests/test_apidata.py
+++ b/tests/test_apidata.py
@@ -13,13 +13,13 @@ from statbank import StatbankClient
 from statbank.api_exceptions import StatbankParameterError
 from statbank.api_exceptions import StatbankVariableSelectionError
 from statbank.api_exceptions import TooBigRequestError
+from statbank.apidata import _check_selection
 from statbank.apidata import apicodelist
 from statbank.apidata import apidata
 from statbank.apidata import apidata_all
 from statbank.apidata import apidata_query_all
 from statbank.apidata import apidata_rotate
 from statbank.apidata import apimetadata
-from statbank.apidata import check_selection
 
 if TYPE_CHECKING:
     from statbank.api_types import QueryWholeType
@@ -274,7 +274,8 @@ def test_client_apidata_rotate_05300(
 
 @mock.patch.object(requests, "post")
 def test_apidata_raises_parameter_error(
-    fake_post: Callable, query_all_05300: pd.DataFrame
+    fake_post: Callable,
+    query_all_05300: pd.DataFrame,
 ) -> None:
     fake_post.return_value = fake_post_parameter_error()
     fake_post.return_value.status_code = 400
@@ -284,7 +285,8 @@ def test_apidata_raises_parameter_error(
 
 @mock.patch.object(requests, "post")
 def test_apidata_raises_variable_error(
-    fake_post: Callable, query_all_05300: pd.DataFrame
+    fake_post: Callable,
+    query_all_05300: pd.DataFrame,
 ) -> None:
     fake_post.return_value = fake_post_variable_error()
     fake_post.return_value.status_code = 400
@@ -294,7 +296,8 @@ def test_apidata_raises_variable_error(
 
 @mock.patch.object(requests, "post")
 def test_apidata_raises_too_big_error(
-    fake_post: Callable, query_all_05300: pd.DataFrame
+    fake_post: Callable,
+    query_all_05300: pd.DataFrame,
 ) -> None:
     fake_post.return_value = fake_post_too_many_values_selected()
     fake_post.return_value.status_code = 403
@@ -345,7 +348,7 @@ def test_check_duplicates_in_selection():
         "response": {"format": "json-stat2"},
     }
 
-    message = check_selection(variable, "05300", request)
+    message = _check_selection(variable, "05300", request)
     expected = "The value(s) 01 is duplicated for variable Avstand1"
     assert message == expected
 
@@ -367,7 +370,7 @@ def test_check_invalid_in_selection(fake_metadata: Callable):
         "response": {"format": "json-stat2"},
     }
 
-    message = check_selection(variable, "05300", request)
+    message = _check_selection(variable, "05300", request)
     expected = (
         "Invalid value(s) 07 and 08 have been specified for the variable Avstand1"
     )
@@ -391,7 +394,7 @@ def test_check_with_wildcard(fake_metadata: Callable):
         "response": {"format": "json-stat2"},
     }
 
-    message = check_selection(variable, "05300", request)
+    message = _check_selection(variable, "05300", request)
     expected = (
         "One of the values for the variable Avstand1 contains a wildcard character (*)."
     )

--- a/tests/test_apidata.py
+++ b/tests/test_apidata.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from requests.exceptions import HTTPError
 
 from statbank import StatbankClient
+from statbank.api_exceptions import StatbankQueryError, TooBigRequestError
 from statbank.apidata import apicodelist
 from statbank.apidata import apidata
 from statbank.apidata import apidata_all
@@ -62,6 +63,39 @@ def fake_post_apidata() -> requests.Response:
     response._content = bytes(  # noqa: SLF001
         '{"class":"dataset","label":"05300: Avstand til nærmeste lokale/sted (prosent), etter avstand, kulturtilbud, statistikkvariabel og år","source":"Statistisk sentralbyrå","updated":"2022-05-24T06:00:00Z","id":["Avstand1","Kulturtilbud","ContentsCode","Tid"],"size":[6,8,1,9],"dimension":{"Avstand1":{"label":"avstand","category":{"index":{"01":0,"02":1,"03":2,"04":3,"05":4,"06":5},"label":{"01":"Under 1 km","02":"1-4,9 km","03":"5-9,9 km","04":"10-24 km","05":"25-49 km","06":"50 km eller over"}}},"Kulturtilbud":{"label":"kulturtilbud","category":{"index":{"01":0,"02":1,"03":2,"04":3,"05":4,"06":5,"07":6,"08":7},"label":{"01":"Kino eller lokale med jevnlig spillefilmframvisning","02":"Teater eller lokale med jevnlige teater- eller operaforestillinger","03":"Konsertsal eller lokale med jevnlige musikkarrangement","04":"Galleri eller lokale med jevnlige kunstutstillinger","05":"Museum","06":"Idrettsplass eller idrettshall","07":"Folkebibliotek","08":"Bokhandel"}}},"ContentsCode":{"label":"statistikkvariabel","category":{"index":{"Avstand":0},"label":{"Avstand":"Avstand til nærmeste lokale/sted"},"unit":{"Avstand":{"base":"prosent","decimals":0}}}},"Tid":{"label":"år","category":{"index":{"1991":0,"1994":1,"1997":2,"2000":3,"2004":4,"2008":5,"2012":6,"2016":7,"2021":8},"label":{"1991":"1991","1994":"1994","1997":"1997","2000":"2000","2004":"2004","2008":"2008","2012":"2012","2016":"2016","2021":"2021"}}}},"value":[16,14,12,12,11,12,10,12,12,7,7,6,6,6,7,7,8,7,8,8,8,8,7,10,9,10,8,11,11,9,10,10,12,10,11,8,10,9,9,9,8,10,8,9,8,38,36,33,32,33,38,34,34,27,23,23,20,18,19,20,18,17,15,20,22,20,19,18,21,18,18,null,39,39,38,35,36,36,39,42,null,23,23,23,23,26,28,30,32,null,26,28,24,25,30,31,34,35,null,33,34,30,29,33,33,36,37,null,32,35,33,32,32,33,34,34,null,44,47,49,48,48,44,48,50,null,50,50,50,51,49,48,50,51,null,42,44,43,42,45,44,46,48,null,21,20,20,19,21,21,20,21,null,16,15,15,15,17,19,18,22,null,16,17,16,16,18,20,19,23,null,18,18,17,18,20,19,19,23,null,22,22,20,19,22,20,22,24,null,11,9,11,11,11,9,11,10,null,16,15,17,17,18,17,18,19,null,18,14,16,16,15,14,16,16,null,18,19,21,22,22,21,21,19,16,16,16,21,22,19,22,22,21,16,17,15,21,21,19,22,19,20,15,16,16,20,20,19,20,20,19,16,21,21,24,23,21,23,20,21,18,6,5,6,6,6,6,6,5,5,9,10,10,10,11,12,11,11,10,12,11,14,14,13,14,13,12,null,7,6,7,9,7,7,7,5,6,38,12,13,14,13,11,11,8,10,34,11,12,13,12,9,10,7,10,22,9,10,10,7,8,8,6,10,15,8,9,10,9,8,10,7,11,1,2,1,1,1,1,1,1,2,2,2,2,3,2,2,2,1,4,8,6,5,7,5,4,4,3,null,null,2,2,3,2,3,3,2,3,null,26,23,19,18,13,12,9,15,null,21,19,16,13,9,8,5,10,null,13,14,11,8,7,7,5,11,null,4,6,6,5,6,6,4,10,null,0,0,0,1,1,0,0,1,null,0,1,0,1,1,1,0,2,null,3,2,2,3,3,3,2,null],"status":{"71":".","80":".","89":".","98":".","107":".","116":".","125":".","134":".","143":".","152":".","161":".","170":".","179":".","188":".","197":".","206":".","215":".","287":".","359":".","360":"..","369":"..","378":"..","387":"..","396":"..","405":"..","414":"..","423":"..","431":"."},"role":{"time":["Tid"],"metric":["ContentsCode"]},"version":"2.0","extension":{"px":{"infofile":"None","tableid":"05300","decimals":0}}}',
         "utf8",
+    )
+    response.request = requests.PreparedRequest()
+    return response
+
+
+def fake_post_too_many_values_selected() -> requests.Response:
+    response = requests.Response()
+    response.status_code = 400
+    response._content = bytes(  # noqa: SLF001
+        r'{"error": "Too many values selected"}',
+        encoding="utf8",
+    )
+    response.request = requests.PreparedRequest()
+    return response
+
+
+def fake_post_parameter_error() -> requests.Response:
+    response = requests.Response()
+    response.status_code = 400
+    response._content = bytes(  # noqa: SLF001
+        r'{"error": "Parameter error"}',
+        encoding="utf8",
+    )
+    response.request = requests.PreparedRequest()
+    return response
+
+
+def fake_post_variable_error() -> requests.Response:
+    response = requests.Response()
+    response.status_code = 400
+    response._content = bytes(  # noqa: SLF001
+        r'{"error": "The request for variable \'Region\' has an error. Please check your query."}',
+        encoding="utf8",
     )
     response.request = requests.PreparedRequest()
     return response
@@ -137,7 +171,7 @@ def apidata_05300(fake_post: Callable, query_all_05300: pd.DataFrame) -> pd.Data
 def test_query_all_raises_500(fake_get: Callable) -> None:
     fake_get.return_value = fake_get_table_meta()
     fake_get.return_value.status_code = 500
-    with pytest.raises(HTTPError) as _:
+    with pytest.raises(expected_exception=HTTPError) as _:
         apidata_query_all("https://data.ssb.no/api/v0/no/table/05300")
 
 
@@ -218,18 +252,18 @@ def test_client_apidata_rotate_05300(
 
 
 @mock.patch.object(requests, "post")
-def test_apidata_raises_400(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
-    fake_post.return_value = fake_post_apidata()
+def test_apidata_raises_query_error(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
+    fake_post.return_value = fake_post_parameter_error()
     fake_post.return_value.status_code = 400
-    with pytest.raises(HTTPError) as _:
+    with pytest.raises(expected_exception=StatbankQueryError) as _:
         apidata("05300", query_all_05300, include_id=True)
 
 
 @mock.patch.object(requests, "post")
-def test_apidata_raises_403(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
-    fake_post.return_value = fake_post_apidata()
+def test_apidata_raises_too_big_error(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
+    fake_post.return_value = fake_post_too_many_values_selected()
     fake_post.return_value.status_code = 403
-    with pytest.raises(HTTPError) as _:
+    with pytest.raises(expected_exception=TooBigRequestError) as _:
         apidata("05300", query_all_05300, include_id=True)
 
 

--- a/tests/test_apidata.py
+++ b/tests/test_apidata.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from typing import Any
 from unittest import mock
 
@@ -9,8 +10,9 @@ from dotenv import load_dotenv
 from requests.exceptions import HTTPError
 
 from statbank import StatbankClient
-from statbank.api_exceptions import StatbankParameterError, StatbankVariableSelectionError, TooBigRequestError
-from statbank.api_types import QueryWholeType
+from statbank.api_exceptions import StatbankParameterError
+from statbank.api_exceptions import StatbankVariableSelectionError
+from statbank.api_exceptions import TooBigRequestError
 from statbank.apidata import apicodelist
 from statbank.apidata import apidata
 from statbank.apidata import apidata_all
@@ -18,6 +20,9 @@ from statbank.apidata import apidata_query_all
 from statbank.apidata import apidata_rotate
 from statbank.apidata import apimetadata
 from statbank.apidata import check_selection
+
+if TYPE_CHECKING:
+    from statbank.api_types import QueryWholeType
 
 load_dotenv()
 
@@ -268,7 +273,9 @@ def test_client_apidata_rotate_05300(
 
 
 @mock.patch.object(requests, "post")
-def test_apidata_raises_parameter_error(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
+def test_apidata_raises_parameter_error(
+    fake_post: Callable, query_all_05300: pd.DataFrame
+) -> None:
     fake_post.return_value = fake_post_parameter_error()
     fake_post.return_value.status_code = 400
     with pytest.raises(expected_exception=StatbankParameterError) as _:
@@ -276,7 +283,9 @@ def test_apidata_raises_parameter_error(fake_post: Callable, query_all_05300: pd
 
 
 @mock.patch.object(requests, "post")
-def test_apidata_raises_variable_error(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
+def test_apidata_raises_variable_error(
+    fake_post: Callable, query_all_05300: pd.DataFrame
+) -> None:
     fake_post.return_value = fake_post_variable_error()
     fake_post.return_value.status_code = 400
     with pytest.raises(expected_exception=StatbankVariableSelectionError) as _:
@@ -284,7 +293,9 @@ def test_apidata_raises_variable_error(fake_post: Callable, query_all_05300: pd.
 
 
 @mock.patch.object(requests, "post")
-def test_apidata_raises_too_big_error(fake_post: Callable, query_all_05300: pd.DataFrame) -> None:
+def test_apidata_raises_too_big_error(
+    fake_post: Callable, query_all_05300: pd.DataFrame
+) -> None:
     fake_post.return_value = fake_post_too_many_values_selected()
     fake_post.return_value.status_code = 403
     with pytest.raises(expected_exception=TooBigRequestError) as _:
@@ -357,7 +368,9 @@ def test_check_invalid_in_selection(fake_metadata: Callable):
     }
 
     message = check_selection(variable, "05300", request)
-    expected = "Invalid value(s) 07 and 08 have been specified for the variable Avstand1"
+    expected = (
+        "Invalid value(s) 07 and 08 have been specified for the variable Avstand1"
+    )
     assert message == expected
 
 
@@ -379,6 +392,8 @@ def test_check_with_wildcard(fake_metadata: Callable):
     }
 
     message = check_selection(variable, "05300", request)
-    expected = "One of the values for the variable Avstand1 contains a wildcard character (*)."
+    expected = (
+        "One of the values for the variable Avstand1 contains a wildcard character (*)."
+    )
     assert message is not None
     assert message.startswith(expected)


### PR DESCRIPTION
Dette PRet forbedrer feilmeldingene man får etter å ha sendt inn en spørring til PxWebApi-et som inneholder feil.

«apidata» funksjonen gir kun feilmeldinger som inneholder en HTTP-statuskode.
Det ikke så hjelpsomt for brukere som ikke vet at HTTP-statuskoden 403 betyr at spørringen er for stor, eller at 400 betyr at det er noe galt med spørringen. Ved HTTP-statuskode 400 leser ikke «apidata» feilmeldingen fra APIet, slik at brukeren ikke får noe hint om hva som er galt med spørringen.

Dette PRet ordner det, og erstatter HTTP-statuskode 400 og 403 med tilpassede feilmeldinger.

Dette PRet går også litt lengre, ved å se etter vanlige feil jeg har observert når bistått andre med å hente data fra apiet, slik som å glemme å fjerne duplikater fra utvalget, eller å glemme å sette filtertypen til "all" når man gjør et utvalg med jokertegn, når apiet forteller at det er noe galt ved utvalget ved en navngitt variabel. 
Hvis filtertypen er av typen "item" eller "vs:" gjøres det et tilslutt et oppslag i kodelista, slik at brukeren får vite hvilke verdier i utvalget som eventuelt er ugyldige. 