### PR TITLE
Downgrade labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0
         with:
           skip-delete: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-statbank-client"
-version = "1.2.7"
+version = "1.2.8"
 description = "Handles data transfer Statbank <-> Dapla for Statistics Norway"
 authors = ["Statistics Norway", "Carl F. Corneil <cfc@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
The labeler is failing, which seems to be a known issue. https://github.com/crazy-max/ghaction-github-labeler/issues/221
Falling back to previously working version.

Thanks to @skykanin package should now work on Dapla Lab.
This PR wil also push new version to Pypi with @Bjoern-Rapp enhancements.
