### PR TITLE
remove warning, bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-statbank-client"
-version = "1.2.9"
+version = "1.2.10"
 description = "Handles data transfer Statbank <-> Dapla for Statistics Norway"
 authors = ["Statistics Norway", "Carl F. Corneil <cfc@ssb.no>"]
 license = "MIT"

--- a/src/statbank/uttrekk_validations.py
+++ b/src/statbank/uttrekk_validations.py
@@ -664,7 +664,6 @@ class StatbankUttrekkValidators:
                 try:
                     if pd.api.types.is_string_dtype(col):
                         col = col.str.replace(",", ".", regex=False)
-                    logger.warning(col)
                     col.astype("Float64")
                 except ValueError as e:
                     validation_errors[


### PR DESCRIPTION
Bumps package version to 1.2.10

Reported on Engage:
https://engage.cloud.microsoft/main/org/ssb.no/threads/eyJfdHlwZSI6IlRocmVhZCIsImlkIjoiMzE3MjI0MDkzOTYyMjQwMCJ9?trk_copy_link=V2

Extra logger.warning used in debug, which I forgot to remove, is now removed. Should have used print() instead, as RUFF catches that on pre-commit. Live and learn.