### PR TITLE
rename 'ignore_klasscodes_not_in_data' -> 'ignore_codes_not_in_data'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-statbank-client"
-version = "1.3.2"
+version = "1.3.3"
 description = "Handles data transfer Statbank <-> Dapla for Statistics Norway"
 authors = ["Statistics Norway", "Carl F. Corneil <cfc@ssb.no>"]
 license = "MIT"

--- a/src/statbank/uttrekk.py
+++ b/src/statbank/uttrekk.py
@@ -218,7 +218,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         self,
         data: dict[str, pd.DataFrame],
         raise_errors: bool = False,
-        ignore_klasscodes_not_in_data: bool = False,
+        ignore_codes_not_in_data: bool = False,
     ) -> dict[str, ValueError]:
         """Uses the contents of itself to validate the data against.
 
@@ -228,7 +228,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         Args:
             data (dict[str, pd.DataFrame]): The data to validate in a dictionary of deltabell-names as keys and pandas-dataframes as values.
             raise_errors (bool): True/False based on if you want the method to raise its own errors or not.
-            ignore_klasscodes_not_in_data (bool): If set to True, will hide messages about codes in klass that are missing from the data.
+            ignore_codes_not_in_data (bool): If set to True, will hide messages about codes in klass that are missing from the data.
 
         Returns:
             dict[str, ValueError]: A dictionary of the errors the validation wants to raise.
@@ -251,7 +251,7 @@ class StatbankUttrekksBeskrivelse(StatbankAuth, StatbankUttrekkValidators):
         validation_errors = self._category_code_usage(
             data,
             validation_errors,
-            ignore_klasscodes_not_in_data,
+            ignore_codes_not_in_data,
         )
         validation_errors = self._check_for_floats(data, validation_errors)
         validation_errors = self._check_for_literal_nans_in_strings(

--- a/src/statbank/uttrekk_validations.py
+++ b/src/statbank/uttrekk_validations.py
@@ -571,10 +571,10 @@ class StatbankUttrekkValidators:
         self,
         data: dict[str, pd.DataFrame],
         validation_errors: dict[str, ValueError],
-        ignore_klasscodes_not_in_data: bool = False,
+        ignore_codes_not_in_data: bool = False,
     ) -> dict[str, ValueError]:
 
-        if not ignore_klasscodes_not_in_data:
+        if not ignore_codes_not_in_data:
             validation_errors = self._check_category_code_usage_missing(
                 data,
                 validation_errors,


### PR DESCRIPTION
Renamed `ignore_klasscodes_not_in_data` to `ignore_codes_not_in_data`, using a simple search and replace: 
```bash 
# dapla-statbank-client/src/
grep -lr "ignore_klasscodes_not_in_data" | xargs sed -i "s/ignore_klasscodes_not_in_data/ignore_codes_not_in_data/g"
```
Also bumped poetry version using
```bash
poetry version patch
```