### PR TITLE
Økt timeout for spørring til PX-apiet

### DIFF
--- a/src/statbank/get_apidata.py
+++ b/src/statbank/get_apidata.py
@@ -73,7 +73,7 @@ def apidata(
     # Spør APIet om å få resultatet med requests-biblioteket
     with r.Session() as s:
         retries = Retry(total=5, backoff_factor=0.1)
-        s.mount("http://", HTTPAdapter(max_retries=retries))
+        s.mount("https://", HTTPAdapter(max_retries=retries))
         resultat = s.post(url, json=payload_now, timeout=20)
 
     if not resultat.ok:

--- a/src/statbank/get_apidata.py
+++ b/src/statbank/get_apidata.py
@@ -9,6 +9,8 @@ from typing import Any
 from typing import TypeVar
 
 import requests as r
+from requests.adapters import HTTPAdapter
+from requests.adapters import Retry
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -69,7 +71,11 @@ def apidata(
 
     logger.info(url)
     # Spør APIet om å få resultatet med requests-biblioteket
-    resultat = r.post(url, json=payload_now, timeout=10)
+    with r.Session() as s:
+        retries = Retry(total=5, backoff_factor=0.1)
+        s.mount("http://", HTTPAdapter(max_retries=retries))
+        resultat = s.post(url, json=payload_now, timeout=20)
+
     if not resultat.ok:
         _read_error(id_or_url, payload_now, resultat)
 

--- a/tests/test_apidata.py
+++ b/tests/test_apidata.py
@@ -302,7 +302,7 @@ def test_client_apidata_rotate_05300(
         assert ind.isdigit()
 
 
-@mock.patch.object(requests, "post")
+@mock.patch.object(requests.Session, "post")
 def test_apidata_raises_parameter_error(
     fake_post: Callable,
     query_all_05300: pd.DataFrame,
@@ -313,7 +313,7 @@ def test_apidata_raises_parameter_error(
         apidata("05300", query_all_05300, include_id=True)
 
 
-@mock.patch.object(requests, "post")
+@mock.patch.object(requests.Session, "post")
 @mock.patch.object(requests, "get")
 def test_apidata_raises_variable_error(
     fake_meta_get: Callable,
@@ -327,7 +327,7 @@ def test_apidata_raises_variable_error(
         apidata("05300", query_all_05300, include_id=True)
 
 
-@mock.patch.object(requests, "post")
+@mock.patch.object(requests.Session, "post")
 def test_apidata_raises_too_big_error(
     fake_post: Callable,
     query_all_05300: pd.DataFrame,
@@ -338,7 +338,7 @@ def test_apidata_raises_too_big_error(
         apidata("05300", query_all_05300, include_id=True)
 
 
-@mock.patch.object(requests, "post")
+@mock.patch.object(requests.Session, "post")
 def test_apidata_raises_500(
     fake_post: Callable,
     query_all_05300: pd.DataFrame,


### PR DESCRIPTION
Jeg opplever ofte at større spørringer til PX-apiet feiler. 
Årsaken ser ut til at timeouten på spørringen fra `apidata` er satt til 10 sekunder. Har økt den til 20 sekunder. Spørringen forsøkes igjen opptil 5 ganger.