### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/dapla-statbank-client/security/code-scanning/3](https://github.com/statisticsnorway/dapla-statbank-client/security/code-scanning/3)

To resolve the problem, the workflow file should include the `permissions` key with the minimal required permissions, ideally at the root level so it applies to all jobs unless a job overrides it. From review, this workflow’s jobs should work with only read permission for repository contents, as none of the steps require actions such as pushing code, modifying issues, or altering pull requests. Therefore, you should add:

```yaml
permissions:
  contents: read
```

This block should be added right after the `name:` at the top of the workflow (after line 1), before `on:`. This ensures all jobs get the least privilege permissions, unless individually overridden.

No further code or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
